### PR TITLE
Fixed potential array out of bounds exception, issue #14 #16

### DIFF
--- a/src/main/java/fi/solita/clamav/ClamAVClient.java
+++ b/src/main/java/fi/solita/clamav/ClamAVClient.java
@@ -154,10 +154,9 @@ public class ClamAVClient {
 
     byte[] buf = new byte[2000];
     int read = 0;
-    do {
-      read = is.read(buf);
-      tmp.write(buf, 0, read);
-    } while ((read > 0) && (is.available() > 0));
+    while ((read = is.read(buf)) != -1) {
+        tmp.write(buf, 0, read);
+    }
     return tmp.toByteArray();
   }
 }


### PR DESCRIPTION
This should likely fix reported issue #14

Because we do the write-call before checking the read response, we might try to write with -1 as the array index
Additionally, I'm not entirely sure of the purpose of the is.available() call. We presumably want to exhaust and read everything until end of stream anyway? This is where I might be wrong though.